### PR TITLE
Fix link to example

### DIFF
--- a/index.html
+++ b/index.html
@@ -49,7 +49,7 @@
                     <a class="nav-link" href="https://github.com/serverlessworkflow/specification" target="_blank"><i class="fa fa-external-link" style="color: #ffffff;"></i> Specification</a>
                 </li>
                 <li class="nav-item">
-                    <a class="nav-link" href="https://github.com/serverlessworkflow/specification/tree/master/specification/examples" target="_blank"><i class="fa fa-external-link" style="color: #ffffff;"></i> Examples</a>
+                    <a class="nav-link" href="https://github.com/serverlessworkflow/specification/tree/master/examples" target="_blank"><i class="fa fa-external-link" style="color: #ffffff;"></i> Examples</a>
                 </li>
                 <li class="nav-item">
                     <a class="nav-link" href="https://github.com/serverlessworkflow/specification/blob/master/specification/community/contributors.md" target="_blank"><i class="fa fa-external-link" style="color: #ffffff;"></i> Contributors</a>


### PR DESCRIPTION
The previous link to example is broken

**What this PR does**:
The previous link to examples is broken
