### PR TITLE
Fixed JSON schema IDs for alpha4 and 5

### DIFF
--- a/static/schemas/1.0.0-alpha4/workflow.json
+++ b/static/schemas/1.0.0-alpha4/workflow.json
@@ -1,5 +1,5 @@
 {
-  "$id": "https://serverlessworkflow.io/schemas/1.0.0-alpha4/workflow.yaml",
+  "$id": "https://serverlessworkflow.io/schemas/1.0.0-alpha4/workflow.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "description": "Serverless Workflow DSL - Workflow Schema.",
   "type": "object",

--- a/static/schemas/1.0.0-alpha5/workflow.json
+++ b/static/schemas/1.0.0-alpha5/workflow.json
@@ -1,5 +1,5 @@
 {
-  "$id": "https://serverlessworkflow.io/schemas/1.0.0-alpha5/workflow.yaml",
+  "$id": "https://serverlessworkflow.io/schemas/1.0.0-alpha5/workflow.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "description": "Serverless Workflow DSL - Workflow Schema.",
   "type": "object",


### PR DESCRIPTION
**Many thanks for submitting your Pull Request :heart:!**

**What this PR does / why we need it**:
The JSON documents for the v1.0.0-alpha4 and alpha5 pointed to the yaml files instead of the json ones.