### PR TITLE
Fixed CORS headers handling

### DIFF
--- a/.netlify/v1/edge-functions/middleware/headers.js
+++ b/.netlify/v1/edge-functions/middleware/headers.js
@@ -1,0 +1,14 @@
+export default async (request, context) => {
+  const response = await context.next();
+  
+  if (request.method === "OPTIONS") {
+    return new Response("ok", {
+      headers: {
+        "Access-Control-Allow-Origin": "*",
+      },
+    });
+  }
+
+  response.headers.set("Access-Control-Allow-Origin", "*");
+  return response;
+};

--- a/_headers
+++ b/_headers
@@ -1,5 +1,8 @@
 # See:  https://docs.netlify.com/routing/headers/
 #       https://answers.netlify.com/t/access-control-allow-origin-policy/1813
+
+# Note: since migration to Astro, this config seems to be ignored. Using edge-function middleware instead (see .netlify/v1/edge-functions/middleware/headers.js as configured in netlify.toml)
+
 /*
   Access-Control-Allow-Origin: *
   Access-Control-Allow-Methods: OPTIONS, GET

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,3 +1,7 @@
 [build]
-command = "npm run build"
-publish = "dist"
+  command = "npm run build"
+  publish = "dist"
+
+[[edge_functions]]
+	path = "/*"
+	function = "headers"


### PR DESCRIPTION
**Many thanks for submitting your Pull Request :heart:!**

**What this PR does / why we need it**:
It seems the `_headers` configuration is ignored since we moved to Astro (I think it was already ignored with Hugo/Docsy), therefore, the header `Access-Control-Allow-Origin: *` is not set and ressources, like the schema, cannot be loaded from an external domains.

The PR adds a netlify edge-function middleware that's supposed to solve the problem.

**Special notes for reviewers**:

**Additional information (if needed):**