### PR TITLE
Update $id URLs in 1.x schema files to open-workflow-specification.org

### DIFF
--- a/static/schemas/1.0.0-alpha1/workflow.json
+++ b/static/schemas/1.0.0-alpha1/workflow.json
@@ -1,5 +1,5 @@
 {
-  "id": "https://serverlessworkflow.io/schemas/1.0.0-alpha1/workflow.json",
+  "id": "https://open-workflow-specification.org/schemas/1.0.0-alpha1/workflow.json",
   "$schema": "http://json-schema.org/draft-07/schema",
   "description": "Serverless Workflow DSL - Workflow Schema",
   "type": "object",

--- a/static/schemas/1.0.0-alpha2/workflow.json
+++ b/static/schemas/1.0.0-alpha2/workflow.json
@@ -1,5 +1,5 @@
 {
-    "$id": "https://serverlessworkflow.io/schemas/1.0.0-alpha2/workflow.json",
+    "$id": "https://open-workflow-specification.org/schemas/1.0.0-alpha2/workflow.json",
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "description": "Serverless Workflow DSL - Workflow Schema",
     "type": "object",

--- a/static/schemas/1.0.0-alpha2/workflow.yaml
+++ b/static/schemas/1.0.0-alpha2/workflow.yaml
@@ -1,4 +1,4 @@
-$id: https://serverlessworkflow.io/schemas/1.0.0-alpha2/workflow.yaml
+$id: https://open-workflow-specification.org/schemas/1.0.0-alpha2/workflow.yaml
 $schema: https://json-schema.org/draft/2020-12/schema
 description: Serverless Workflow DSL - Workflow Schema
 type: object

--- a/static/schemas/1.0.0-alpha3/workflow.json
+++ b/static/schemas/1.0.0-alpha3/workflow.json
@@ -1,5 +1,5 @@
 {
-  "$id": "https://serverlessworkflow.io/schemas/1.0.0-alpha3/workflow.json",
+  "$id": "https://open-workflow-specification.org/schemas/1.0.0-alpha3/workflow.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "description": "Serverless Workflow DSL - Workflow Schema.",
   "type": "object",

--- a/static/schemas/1.0.0-alpha3/workflow.yaml
+++ b/static/schemas/1.0.0-alpha3/workflow.yaml
@@ -1,4 +1,4 @@
-$id: https://serverlessworkflow.io/schemas/1.0.0-alpha3/workflow.yaml
+$id: https://open-workflow-specification.org/schemas/1.0.0-alpha3/workflow.yaml
 $schema: https://json-schema.org/draft/2020-12/schema
 description: Serverless Workflow DSL - Workflow Schema.
 type: object

--- a/static/schemas/1.0.0-alpha4/workflow.json
+++ b/static/schemas/1.0.0-alpha4/workflow.json
@@ -1,5 +1,5 @@
 {
-  "$id": "https://serverlessworkflow.io/schemas/1.0.0-alpha4/workflow.json",
+  "$id": "https://open-workflow-specification.org/schemas/1.0.0-alpha4/workflow.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "description": "Serverless Workflow DSL - Workflow Schema.",
   "type": "object",

--- a/static/schemas/1.0.0-alpha4/workflow.yaml
+++ b/static/schemas/1.0.0-alpha4/workflow.yaml
@@ -1,4 +1,4 @@
-$id: https://serverlessworkflow.io/schemas/1.0.0-alpha4/workflow.yaml
+$id: https://open-workflow-specification.org/schemas/1.0.0-alpha4/workflow.yaml
 $schema: https://json-schema.org/draft/2020-12/schema
 description: Serverless Workflow DSL - Workflow Schema.
 type: object

--- a/static/schemas/1.0.0-alpha5/workflow.json
+++ b/static/schemas/1.0.0-alpha5/workflow.json
@@ -1,5 +1,5 @@
 {
-  "$id": "https://serverlessworkflow.io/schemas/1.0.0-alpha5/workflow.json",
+  "$id": "https://open-workflow-specification.org/schemas/1.0.0-alpha5/workflow.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "description": "Serverless Workflow DSL - Workflow Schema.",
   "type": "object",

--- a/static/schemas/1.0.0-alpha5/workflow.yaml
+++ b/static/schemas/1.0.0-alpha5/workflow.yaml
@@ -1,4 +1,4 @@
-$id: https://serverlessworkflow.io/schemas/1.0.0-alpha5/workflow.yaml
+$id: https://open-workflow-specification.org/schemas/1.0.0-alpha5/workflow.yaml
 $schema: https://json-schema.org/draft/2020-12/schema
 description: Serverless Workflow DSL - Workflow Schema.
 type: object

--- a/static/schemas/1.0.0/workflow.json
+++ b/static/schemas/1.0.0/workflow.json
@@ -1,5 +1,5 @@
 {
-  "$id": "https://serverlessworkflow.io/schemas/1.0.0/workflow.json",
+  "$id": "https://open-workflow-specification.org/schemas/1.0.0/workflow.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "description": "Serverless Workflow DSL - Workflow Schema.",
   "type": "object",

--- a/static/schemas/1.0.0/workflow.yaml
+++ b/static/schemas/1.0.0/workflow.yaml
@@ -1,4 +1,4 @@
-$id: https://serverlessworkflow.io/schemas/1.0.0/workflow.yaml
+$id: https://open-workflow-specification.org/schemas/1.0.0/workflow.yaml
 $schema: https://json-schema.org/draft/2020-12/schema
 description: Serverless Workflow DSL - Workflow Schema.
 type: object

--- a/static/schemas/1.0.1/workflow.json
+++ b/static/schemas/1.0.1/workflow.json
@@ -1,5 +1,5 @@
 {
-  "$id": "https://serverlessworkflow.io/schemas/1.0.1/workflow.yaml",
+  "$id": "https://open-workflow-specification.org/schemas/1.0.1/workflow.yaml",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "description": "Serverless Workflow DSL - Workflow Schema.",
   "type": "object",

--- a/static/schemas/1.0.1/workflow.yaml
+++ b/static/schemas/1.0.1/workflow.yaml
@@ -1,4 +1,4 @@
-$id: https://serverlessworkflow.io/schemas/1.0.1/workflow.yaml
+$id: https://open-workflow-specification.org/schemas/1.0.1/workflow.yaml
 $schema: https://json-schema.org/draft/2020-12/schema
 description: Serverless Workflow DSL - Workflow Schema.
 type: object

--- a/static/schemas/1.0.3/workflow.json
+++ b/static/schemas/1.0.3/workflow.json
@@ -1,5 +1,5 @@
 {
-  "$id": "https://serverlessworkflow.io/schemas/1.0.3/workflow.yaml",
+  "$id": "https://open-workflow-specification.org/schemas/1.0.3/workflow.yaml",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "description": "Serverless Workflow DSL - Workflow Schema.",
   "type": "object",

--- a/static/schemas/1.0.3/workflow.yaml
+++ b/static/schemas/1.0.3/workflow.yaml
@@ -1,4 +1,4 @@
-$id: https://serverlessworkflow.io/schemas/1.0.3/workflow.yaml
+$id: https://open-workflow-specification.org/schemas/1.0.3/workflow.yaml
 $schema: https://json-schema.org/draft/2020-12/schema
 description: Serverless Workflow DSL - Workflow Schema.
 type: object


### PR DESCRIPTION
## Summary
- Updates `$id` URLs in all 1.x schema files from `serverlessworkflow.io` to `open-workflow-specification.org`
- 0.x schema files are intentionally left unchanged (they should continue pointing to the legacy domain)
- 15 files updated across versions 1.0.0-alpha1 through 1.0.3 (both `.json` and `.yaml`)

Fixes #269